### PR TITLE
Add reasoning_content support to OpenAI response

### DIFF
--- a/skythought/evals/inference_and_check.py
+++ b/skythought/evals/inference_and_check.py
@@ -138,7 +138,13 @@ def _parse_response_for_idx(
     sample_idx: int,
 ) -> Tuple[SingleParsedResponse, Dict[str, int]]:
     content = response.response[sample_idx].strip()
-    response_entry = SingleParsedResponse(content=content)
+    reasoning = None
+    if (
+        response.reasoning_content is not None
+        and len(response.reasoning_content) > sample_idx
+    ):
+        reasoning = response.reasoning_content[sample_idx]
+    response_entry = SingleParsedResponse(content=content, reasoning_content=reasoning)
 
     token_usage_for_response = {
         "completion_tokens": response.num_completion_tokens[sample_idx],

--- a/skythought/evals/util/response.py
+++ b/skythought/evals/util/response.py
@@ -4,10 +4,17 @@ from typing import List, Optional
 
 @dataclass
 class Response:
+    """Aggregate response information from a model backend."""
+
+    # Text for each generated sample
     response: List[str]
+    # Token counts for the corresponding completions
     num_completion_tokens: List[int]
+    # Number of tokens in the input prompt
     num_input_tokens: int
+    # Optional reasoning content provided by the backend, one entry per sample
     reasoning_content: Optional[List[str]] = None
+    # Optional index of the request within the dataset
     index: Optional[int] = None
 
     @classmethod

--- a/skythought/evals/util/response.py
+++ b/skythought/evals/util/response.py
@@ -5,9 +5,9 @@ from typing import List, Optional
 @dataclass
 class Response:
     response: List[str]
-    reasoning_content: Optional[List[str]] = None
     num_completion_tokens: List[int]
     num_input_tokens: int
+    reasoning_content: Optional[List[str]] = None
     index: Optional[int] = None
 
     @classmethod
@@ -55,15 +55,15 @@ class Response:
                 response.choices[i].message.content
                 for i in range(len(response.choices))
             ],
-            reasoning_content=[
-                getattr(response.choices[i].message, "reasoning_content", None)
-                for i in range(len(response.choices))
-            ],
             num_completion_tokens=[
                 response.usage.completion_tokens if i == 0 else 0
                 for i in range(len(response.choices))
             ],
             num_input_tokens=response.usage.prompt_tokens,
+            reasoning_content=[
+                getattr(response.choices[i].message, "reasoning_content", None)
+                for i in range(len(response.choices))
+            ],
         )
 
     @classmethod

--- a/skythought/evals/util/response.py
+++ b/skythought/evals/util/response.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 @dataclass
 class Response:
     response: List[str]
+    reasoning_content: Optional[List[str]] = None
     num_completion_tokens: List[int]
     num_input_tokens: int
     index: Optional[int] = None
@@ -54,6 +55,10 @@ class Response:
                 response.choices[i].message.content
                 for i in range(len(response.choices))
             ],
+            reasoning_content=[
+                getattr(response.choices[i].message, "reasoning_content", None)
+                for i in range(len(response.choices))
+            ],
             num_completion_tokens=[
                 response.usage.completion_tokens if i == 0 else 0
                 for i in range(len(response.choices))
@@ -90,10 +95,12 @@ class SingleParsedResponse:
     content: str
     correctness: Optional[bool] = None
     reason: Optional[str] = None
+    reasoning_content: Optional[str] = None
 
     def to_dict(self):
         return {
             "content": self.content,
             "correctness": self.correctness,
             "reason": self.reason,
+            "reasoning_content": self.reasoning_content,
         }


### PR DESCRIPTION
## Summary
- track `reasoning_content` in `Response` and `SingleParsedResponse`
- parse reasoning content from OpenAI chat responses
- include reasoning when converting responses in evaluation

## Testing
- `pre-commit run --files skythought/evals/util/response.py skythought/evals/inference_and_check.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_686d6f1a268c832c8f98ce1b76116079